### PR TITLE
fix: Configure React Router basename for GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename="/ai-dev">
         <Layout>
           <Routes>
             <Route path="/" element={<Index />} />


### PR DESCRIPTION
Set the `basename` prop on `BrowserRouter` to "/ai-dev" to ensure correct routing when your application is deployed to a subdirectory on GitHub Pages.

This resolves an issue where your application would load but show a blank page or a 404 error within the router because it was not aware of the subpath.